### PR TITLE
Ensure Firebase initializes before auth usage

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -14,5 +14,6 @@ const firebaseConfig = {
 
 
 const app = initializeApp(firebaseConfig)
-getAuth(app)
-getDatabase(app)
+
+export const auth = getAuth(app)
+export const db = getDatabase(app)

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
+import './firebase'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
-import './firebase'
 import './index.css'
 
 const app = createApp(App)

--- a/src/stores/questionnaires.js
+++ b/src/stores/questionnaires.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { db } from '../firebase'
 import {
-  getDatabase,
   ref as dbRef,
   get,
   query,
@@ -10,7 +10,6 @@ import {
 } from 'firebase/database'
 
 export const useQuestionnaireStore = defineStore('questionnaires', () => {
-  const db = getDatabase()
   const published = ref([])
   const current = ref(null)
   const sections = ref([])

--- a/src/stores/responses.js
+++ b/src/stores/responses.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { db } from '../firebase'
 import {
-  getDatabase,
   ref as dbRef,
   push,
   set,
@@ -12,7 +12,6 @@ import html2canvas from 'html2canvas'
 import { useUserStore } from './user'
 
 export const useResponseStore = defineStore('responses', () => {
-  const db = getDatabase()
   const userStore = useUserStore()
   const responseId = ref(null)
   const answers = ref({})

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { getAuth, onAuthStateChanged, signInAnonymously, signOut } from 'firebase/auth'
+import { onAuthStateChanged, signInAnonymously, signOut } from 'firebase/auth'
+import { auth } from '../firebase'
 
 export const useUserStore = defineStore('user', () => {
-  const auth = getAuth()
   const user = ref(null)
 
   onAuthStateChanged(auth, (u) => (user.value = u))

--- a/src/views/admin/Dashboard.vue
+++ b/src/views/admin/Dashboard.vue
@@ -1,8 +1,7 @@
 <script setup>
 import { onMounted, ref } from 'vue'
-import { getDatabase, ref as dbRef, get } from 'firebase/database'
-
-const db = getDatabase()
+import { db } from '../../firebase'
+import { ref as dbRef, get } from 'firebase/database'
 const counts = ref({ questionnaires: 0, responses: 0, users: 0 })
 
 onMounted(async () => {

--- a/src/views/admin/QuestionnaireBuilder.vue
+++ b/src/views/admin/QuestionnaireBuilder.vue
@@ -1,10 +1,10 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { getDatabase, ref as dbRef, push, set, update, get } from 'firebase/database'
+import { db } from '../../firebase'
+import { ref as dbRef, push, set, update, get } from 'firebase/database'
 
 const route = useRoute()
-const db = getDatabase()
 
 const questionnaire = ref({ title: '', description: '', status: 'draft' })
 const sections = ref([])

--- a/src/views/admin/Responses.vue
+++ b/src/views/admin/Responses.vue
@@ -1,8 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getDatabase, ref as dbRef, get } from 'firebase/database'
-
-const db = getDatabase()
+import { db } from '../../firebase'
+import { ref as dbRef, get } from 'firebase/database'
 const responses = ref([])
 
 onMounted(async () => {

--- a/src/views/admin/Users.vue
+++ b/src/views/admin/Users.vue
@@ -1,8 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getDatabase, ref as dbRef, get } from 'firebase/database'
-
-const db = getDatabase()
+import { db } from '../../firebase'
+import { ref as dbRef, get } from 'firebase/database'
 const users = ref([])
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- Initialize and export shared `auth`/`db` instances from `firebase.js`
- Import shared Firebase instances in stores and admin views instead of calling `getAuth`/`getDatabase`
- Load Firebase configuration before other modules by moving import to the top of `main.js`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b448e284f4832eb50e875337c58997