### PR TITLE
Implement email-based auth with admin and customer roles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,25 +9,37 @@ const userStore = useUserStore()
   <div>
     <nav class="bg-gray-800 text-white p-4 flex gap-4 items-center">
       <RouterLink to="/" class="hover:underline">Home</RouterLink>
-      <RouterLink to="/admin" class="hover:underline" v-if="userStore.user">Admin</RouterLink>
       <RouterLink
-        v-if="userStore.user"
+        to="/admin"
+        class="hover:underline"
+        v-if="userStore.isAdmin"
+        >Admin</RouterLink
+      >
+      <RouterLink
+        v-if="userStore.isAdmin"
         to="/admin/questionnaires"
         class="hover:underline"
       >Add Questionnaire</RouterLink>
 
       <div class="ml-auto flex gap-4 items-center">
-        <button
-          v-if="!userStore.user"
-          @click="userStore.signInAnon"
+        <RouterLink
+          v-if="!userStore.authUser"
+          to="/login"
           class="hover:underline"
-        >Login</button>
+          >Login</RouterLink
+        >
+        <RouterLink
+          v-if="!userStore.authUser"
+          to="/register"
+          class="hover:underline"
+          >Register</RouterLink
+        >
         <button
           v-else
-          @click="userStore.signOut"
+          @click="userStore.logout"
           class="hover:underline"
         >Logout</button>
-        <span v-if="userStore.user">{{ userStore.user.email || 'Guest' }}</span>
+        <span v-if="userStore.authUser">{{ userStore.profile?.email }}</span>
       </div>
     </nav>
     <RouterView />

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,10 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { useUserStore } from '../stores/user'
 
 import Questionnaires from '../views/Questionnaires.vue'
 import QuestionnaireRunner from '../views/QuestionnaireRunner.vue'
+import Login from '../views/Login.vue'
+import Register from '../views/Register.vue'
 import AdminDashboard from '../views/admin/Dashboard.vue'
 import AdminQuestionnaire from '../views/admin/QuestionnaireBuilder.vue'
 import AdminResponses from '../views/admin/Responses.vue'
@@ -10,15 +13,44 @@ import AdminUsers from '../views/admin/Users.vue'
 const routes = [
   { path: '/', name: 'questionnaires', component: Questionnaires },
   { path: '/run/:id', name: 'run', component: QuestionnaireRunner },
-  { path: '/admin', name: 'admin-dashboard', component: AdminDashboard },
-  { path: '/admin/questionnaires/:id?', name: 'admin-questionnaire', component: AdminQuestionnaire },
-  { path: '/admin/responses', name: 'admin-responses', component: AdminResponses },
-  { path: '/admin/users', name: 'admin-users', component: AdminUsers }
+  { path: '/login', name: 'login', component: Login },
+  { path: '/register', name: 'register', component: Register },
+  {
+    path: '/admin',
+    name: 'admin-dashboard',
+    component: AdminDashboard,
+    meta: { requiresAdmin: true }
+  },
+  {
+    path: '/admin/questionnaires/:id?',
+    name: 'admin-questionnaire',
+    component: AdminQuestionnaire,
+    meta: { requiresAdmin: true }
+  },
+  {
+    path: '/admin/responses',
+    name: 'admin-responses',
+    component: AdminResponses,
+    meta: { requiresAdmin: true }
+  },
+  {
+    path: '/admin/users',
+    name: 'admin-users',
+    component: AdminUsers,
+    meta: { requiresAdmin: true }
+  }
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes
+})
+
+router.beforeEach((to) => {
+  const userStore = useUserStore()
+  if (to.meta.requiresAdmin && !userStore.isAdmin) {
+    return { name: 'login' }
+  }
 })
 
 export default router

--- a/src/stores/responses.js
+++ b/src/stores/responses.js
@@ -21,7 +21,7 @@ export const useResponseStore = defineStore('responses', () => {
     responseId.value = resRef.key
     await set(resRef, {
       questionnaireId,
-      userId: userStore.user?.uid || null,
+      userId: userStore.authUser?.uid || null,
       createdAt: Date.now(),
       submittedAt: null,
       answers: {}

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useUserStore } from '../stores/user'
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const router = useRouter()
+const userStore = useUserStore()
+
+async function submit() {
+  try {
+    await userStore.login(email.value, password.value)
+    router.push(userStore.isAdmin ? '/admin' : '/')
+  } catch (e) {
+    error.value = e.message
+  }
+}
+</script>
+
+<template>
+  <div class="max-w-md mx-auto p-4">
+    <h1 class="text-2xl mb-4">Login</h1>
+    <form @submit.prevent="submit" class="space-y-4">
+      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" required />
+      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" required />
+      <div v-if="error" class="text-red-600">{{ error }}</div>
+      <button type="submit" class="bg-blue-500 text-white px-4 py-2">Login</button>
+    </form>
+  </div>
+</template>

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useUserStore } from '../stores/user'
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const router = useRouter()
+const userStore = useUserStore()
+
+async function submit() {
+  try {
+    await userStore.register(email.value, password.value)
+    router.push('/')
+  } catch (e) {
+    error.value = e.message
+  }
+}
+</script>
+
+<template>
+  <div class="max-w-md mx-auto p-4">
+    <h1 class="text-2xl mb-4">Register</h1>
+    <form @submit.prevent="submit" class="space-y-4">
+      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" required />
+      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" required />
+      <div v-if="error" class="text-red-600">{{ error }}</div>
+      <button type="submit" class="bg-blue-500 text-white px-4 py-2">Register</button>
+    </form>
+  </div>
+</template>

--- a/src/views/admin/Users.vue
+++ b/src/views/admin/Users.vue
@@ -1,15 +1,22 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { db } from '../../firebase'
-import { ref as dbRef, get } from 'firebase/database'
+import { ref as dbRef, get, update } from 'firebase/database'
 const users = ref([])
 
-onMounted(async () => {
+async function loadUsers() {
   const snap = await get(dbRef(db, 'users'))
   users.value = snap.exists()
     ? Object.entries(snap.val()).map(([id, v]) => ({ id, ...v }))
     : []
-})
+}
+
+async function changeRole(u, role) {
+  await update(dbRef(db, `users/${u.id}`), { role })
+  u.role = role
+}
+
+onMounted(loadUsers)
 </script>
 
 <template>
@@ -27,7 +34,12 @@ onMounted(async () => {
         <tr v-for="u in users" :key="u.id">
           <td class="p-2 border">{{ u.id }}</td>
           <td class="p-2 border">{{ u.email }}</td>
-          <td class="p-2 border">{{ u.role }}</td>
+          <td class="p-2 border">
+            <select v-model="u.role" @change="changeRole(u, u.role)" class="border p-1">
+              <option value="customer">customer</option>
+              <option value="admin">admin</option>
+            </select>
+          </td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- Introduce Pinia user store using Firebase email/password auth with default admin seeded
- Add login and registration pages and update navigation
- Protect admin routes and allow admin to edit user roles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b489451710832eb9286269390758c7