### PR TITLE
Improve dashboard theme and responsiveness

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,9 +6,11 @@ const userStore = useUserStore()
 </script>
 
 <template>
-  <div>
-    <nav class="bg-gray-800 text-white p-4 flex gap-4 items-center">
-      <RouterLink to="/" class="hover:underline">Home</RouterLink>
+  <div class="min-h-screen bg-slate-100">
+    <nav
+      class="bg-slate-800 text-white p-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4 shadow"
+    >
+      <RouterLink to="/" class="hover:underline font-semibold">Home</RouterLink>
       <RouterLink
         to="/admin"
         class="hover:underline"
@@ -19,9 +21,10 @@ const userStore = useUserStore()
         v-if="userStore.isAdmin"
         to="/admin/questionnaires"
         class="hover:underline"
-      >Add Questionnaire</RouterLink>
+        >Add Questionnaire</RouterLink
+      >
 
-      <div class="ml-auto flex gap-4 items-center">
+      <div class="sm:ml-auto flex gap-4 items-center">
         <RouterLink
           v-if="!userStore.authUser"
           to="/login"

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html,
+body,
+#app {
+  @apply min-h-screen bg-slate-100 text-gray-900;
+}

--- a/src/views/admin/Dashboard.vue
+++ b/src/views/admin/Dashboard.vue
@@ -18,18 +18,65 @@ onMounted(async () => {
 <template>
   <div class="p-4">
     <h1 class="text-2xl font-bold mb-4">Admin Dashboard</h1>
-    <div class="grid grid-cols-3 gap-4">
-      <div class="p-4 bg-gray-100 rounded text-center">
-        <div class="text-lg font-semibold">Questionnaires</div>
-        <div class="text-3xl">{{ counts.questionnaires }}</div>
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="p-4 rounded shadow flex items-center justify-between text-white bg-emerald-500">
+        <div>
+          <div class="text-sm">Questionnaires</div>
+          <div class="text-3xl font-bold">{{ counts.questionnaires }}</div>
+        </div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-10 h-10 opacity-75"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M7.502 6h7.128A3.375 3.375 0 0 1 18 9.375v9.375a3 3 0 0 0 3-3V6.108c0-1.505-1.125-2.811-2.664-2.904a48.972 48.972 0 0 0-.673-.05A3 3 0 0 0 15 1.5h-1.5a3 3 0 0 0-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6ZM13.5 3A1.5 1.5 0 0 0 12 4.5h4.5A1.5 1.5 0 0 0 15 3h-1.5Z"
+            clip-rule="evenodd"
+          />
+          <path
+            fill-rule="evenodd"
+            d="M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 0 1 3 20.625V9.375ZM6 12a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V12Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 15a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V15Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 18a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V18Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75Z"
+            clip-rule="evenodd"
+          />
+        </svg>
       </div>
-      <div class="p-4 bg-gray-100 rounded text-center">
-        <div class="text-lg font-semibold">Responses</div>
-        <div class="text-3xl">{{ counts.responses }}</div>
+
+      <div class="p-4 rounded shadow flex items-center justify-between text-white bg-rose-500">
+        <div>
+          <div class="text-sm">Responses</div>
+          <div class="text-3xl font-bold">{{ counts.responses }}</div>
+        </div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-10 h-10 opacity-75"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M4.848 2.771A49.144 49.144 0 0 1 12 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97a48.901 48.901 0 0 1-3.476.383.39.39 0 0 0-.297.17l-2.755 4.133a.75.75 0 0 1-1.248 0l-2.755-4.133a.39.39 0 0 0-.297-.17 48.9 48.9 0 0 1-3.476-.384c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97ZM6.75 8.25a.75.75 0 0 1 .75-.75h9a.75.75 0 0 1 0 1.5h-9a.75.75 0 0 1-.75-.75Zm.75 2.25a.75.75 0 0 0 0 1.5H12a.75.75 0 0 0 0-1.5H7.5Z"
+            clip-rule="evenodd"
+          />
+        </svg>
       </div>
-      <div class="p-4 bg-gray-100 rounded text-center">
-        <div class="text-lg font-semibold">Clients</div>
-        <div class="text-3xl">{{ counts.users }}</div>
+
+      <div class="p-4 rounded shadow flex items-center justify-between text-white bg-amber-500">
+        <div>
+          <div class="text-sm">Clients</div>
+          <div class="text-3xl font-bold">{{ counts.users }}</div>
+        </div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-10 h-10 opacity-75"
+        >
+          <path
+            d="M4.5 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM14.25 8.625a3.375 3.375 0 1 1 6.75 0 3.375 3.375 0 0 1-6.75 0ZM1.5 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM17.25 19.128l-.001.144a2.25 2.25 0 0 1-.233.96 10.088 10.088 0 0 0 5.06-1.01.75.75 0 0 0 .42-.643 4.875 4.875 0 0 0-6.957-4.611 8.586 8.586 0 0 1 1.71 5.157v.003Z"
+          />
+        </svg>
       </div>
     </div>
     <div class="mt-4">


### PR DESCRIPTION
## Summary
- Apply global slate background and text styling
- Revamp navigation bar with dark theme and mobile layout
- Redesign admin dashboard with responsive colored stat cards

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b48b209888832ebe6a6be8d0e73f12