### PR TITLE
feat: improve questionnaire builder and admin links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.1",
         "pinia": "^3.0.3",
+        "sweetalert2": "^11.22.5",
         "vue": "^3.5.18",
         "vue-router": "^4.3.0"
       },
@@ -4755,6 +4756,16 @@
       "optional": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.22.5",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.22.5.tgz",
+      "integrity": "sha512-k9gb2M0n4b830FaWDmqaFQULIRvKixTbJOBkTN5KwRNIT8UxjGxusC9g67cj8sCxkJb9nVy2+PgyVd7vYK7cug==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "pinia": "^3.0.3",
-    "vue": "^3.5.18",
-    "vue-router": "^4.3.0",
     "firebase": "^10.12.4",
+    "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",
-    "html2canvas": "^1.4.1"
+    "pinia": "^3.0.3",
+    "sweetalert2": "^11.22.5",
+    "vue": "^3.5.18",
+    "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/views/admin/Dashboard.vue
+++ b/src/views/admin/Dashboard.vue
@@ -79,9 +79,12 @@ onMounted(async () => {
         </svg>
       </div>
     </div>
-    <div class="mt-4">
+    <div class="mt-4 space-x-4">
       <RouterLink to="/admin/questionnaires" class="text-blue-600 underline"
         >New Questionnaire</RouterLink
+      >
+      <RouterLink to="/admin/users" class="text-blue-600 underline"
+        >Manage Clients</RouterLink
       >
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show SweetAlert2 messages when saving questionnaires or adding sections
- ensure new questionnaires redirect for section management
- add link to manage clients from admin dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b48c8c7c34832eae217c9a5847369d