### PR TITLE
feat: persistent auth and question management

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app'
-import { getAuth } from 'firebase/auth'
+import { getAuth, setPersistence, browserLocalPersistence } from 'firebase/auth'
 import { getDatabase } from 'firebase/database'
 
 const firebaseConfig = {
@@ -16,4 +16,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig)
 
 export const auth = getAuth(app)
+// Persist authentication state in localStorage so users stay logged in until explicitly logging out
+setPersistence(auth, browserLocalPersistence)
 export const db = getDatabase(app)


### PR DESCRIPTION
## Summary
- keep Firebase auth state in local storage for persistent sessions
- allow admins to add questions within questionnaire sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b48e694250832ea134bb2c4ce3b77e