### PR TITLE
feat: enhance questionnaire management

### DIFF
--- a/src/stores/responses.js
+++ b/src/stores/responses.js
@@ -8,11 +8,12 @@ import {
   update
 } from 'firebase/database'
 import jsPDF from 'jspdf'
-import html2canvas from 'html2canvas'
 import { useUserStore } from './user'
+import { useQuestionnaireStore } from './questionnaires'
 
 export const useResponseStore = defineStore('responses', () => {
   const userStore = useUserStore()
+  const qStore = useQuestionnaireStore()
   const responseId = ref(null)
   const answers = ref({})
 
@@ -44,13 +45,38 @@ export const useResponseStore = defineStore('responses', () => {
     })
 
     const doc = new jsPDF()
-    const element = document.body
-    const canvas = await html2canvas(element)
-    const imgData = canvas.toDataURL('image/png')
-    const imgProps = doc.getImageProperties(imgData)
-    const pdfWidth = doc.internal.pageSize.getWidth()
-    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width
-    doc.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight)
+    let y = 10
+    doc.setFontSize(16)
+    if (qStore.current) {
+      doc.text(qStore.current.title || 'Response', 10, y)
+      y += 10
+    }
+    doc.setFontSize(12)
+    for (const section of qStore.sections) {
+      if (section.adminOnly && !userStore.isAdmin) continue
+      if (y > 270) {
+        doc.addPage()
+        y = 10
+      }
+      doc.setFont(undefined, 'bold')
+      doc.text(section.title, 10, y)
+      y += 8
+      doc.setFont(undefined, 'normal')
+      for (const q of qStore.questionsBySection(section.id)) {
+        const ans = answers.value[q.id] ?? ''
+        const line = `${q.prompt}: ${ans}`
+        const lines = doc.splitTextToSize(line, 190)
+        for (const l of lines) {
+          if (y > 280) {
+            doc.addPage()
+            y = 10
+          }
+          doc.text(l, 10, y)
+          y += 7
+        }
+      }
+      y += 4
+    }
     doc.save('response.pdf')
   }
 

--- a/src/views/QuestionnaireRunner.vue
+++ b/src/views/QuestionnaireRunner.vue
@@ -1,12 +1,14 @@
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useQuestionnaireStore } from '../stores/questionnaires'
 import { useResponseStore } from '../stores/responses'
+import { useUserStore } from '../stores/user'
 
 const route = useRoute()
 const qStore = useQuestionnaireStore()
 const rStore = useResponseStore()
+const userStore = useUserStore()
 
 onMounted(async () => {
   await qStore.fetchOne(route.params.id)
@@ -20,13 +22,17 @@ function saveAnswer(id, value) {
 function submit() {
   rStore.submit()
 }
+
+const visibleSections = computed(() =>
+  userStore.isAdmin ? qStore.sections : qStore.sections.filter((s) => !s.adminOnly)
+)
 </script>
 
 <template>
   <div class="p-4" v-if="qStore.current">
     <h1 class="text-2xl font-bold mb-4">{{ qStore.current.title }}</h1>
     <div
-      v-for="section in qStore.sections.filter(s => !s.adminOnly)"
+      v-for="section in visibleSections"
       :key="section.id"
       class="mb-6"
     >

--- a/src/views/admin/Responses.vue
+++ b/src/views/admin/Responses.vue
@@ -2,7 +2,10 @@
 import { ref, onMounted } from 'vue'
 import { db } from '../../firebase'
 import { ref as dbRef, get } from 'firebase/database'
+import { useQuestionnaireStore } from '../../stores/questionnaires'
 const responses = ref([])
+const selected = ref(null)
+const qStore = useQuestionnaireStore()
 
 onMounted(async () => {
   const snap = await get(dbRef(db, 'responses'))
@@ -10,6 +13,11 @@ onMounted(async () => {
     ? Object.entries(snap.val()).map(([id, v]) => ({ id, ...v }))
     : []
 })
+
+async function viewResponse(r) {
+  await qStore.fetchOne(r.questionnaireId)
+  selected.value = r
+}
 </script>
 
 <template>
@@ -22,6 +30,7 @@ onMounted(async () => {
           <th class="p-2 border">Questionnaire</th>
           <th class="p-2 border">User</th>
           <th class="p-2 border">Submitted</th>
+          <th class="p-2 border">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -30,8 +39,22 @@ onMounted(async () => {
           <td class="p-2 border">{{ r.questionnaireId }}</td>
           <td class="p-2 border">{{ r.userId }}</td>
           <td class="p-2 border">{{ r.submittedAt ? new Date(r.submittedAt).toLocaleDateString() : 'Draft' }}</td>
+          <td class="p-2 border"><button class="text-blue-600 underline" @click="viewResponse(r)">View</button></td>
         </tr>
       </tbody>
     </table>
+
+    <div v-if="selected" class="mt-6">
+      <h2 class="text-xl font-bold mb-4">Response {{ selected.id }}</h2>
+      <div v-for="section in qStore.sections" :key="section.id" class="mb-4">
+        <h3 class="font-semibold mb-2">{{ section.title }}</h3>
+        <ul class="pl-4 list-disc">
+          <li v-for="q in qStore.questionsBySection(section.id)" :key="q.id">
+            <strong>{{ q.prompt }}:</strong>
+            {{ selected.answers?.[q.id]?.value || selected.answers?.[q.id] || '' }}
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- allow marking sections as admin-only and remove entire questionnaire templates
- render response PDFs with formatted text instead of screenshots
- view questionnaire responses grouped by section in admin panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b48fde1dfc832ebd71d4b00420822a