### PR TITLE
Add admin results view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -23,6 +23,12 @@ const userStore = useUserStore()
         class="hover:underline"
         >Add Questionnaire</RouterLink
       >
+      <RouterLink
+        v-if="userStore.isAdmin"
+        to="/admin/results"
+        class="hover:underline"
+        >Results</RouterLink
+      >
 
       <div class="sm:ml-auto flex gap-4 items-center">
         <RouterLink

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ import AdminDashboard from '../views/admin/Dashboard.vue'
 import AdminQuestionnaire from '../views/admin/QuestionnaireBuilder.vue'
 import AdminResponses from '../views/admin/Responses.vue'
 import AdminUsers from '../views/admin/Users.vue'
+import AdminResults from '../views/admin/Results.vue'
 
 const routes = [
   { path: '/', name: 'questionnaires', component: Questionnaires },
@@ -37,6 +38,12 @@ const routes = [
     path: '/admin/users',
     name: 'admin-users',
     component: AdminUsers,
+    meta: { requiresAdmin: true }
+  },
+  {
+    path: '/admin/results',
+    name: 'admin-results',
+    component: AdminResults,
     meta: { requiresAdmin: true }
   }
 ]

--- a/src/views/admin/Dashboard.vue
+++ b/src/views/admin/Dashboard.vue
@@ -86,6 +86,9 @@ onMounted(async () => {
       <RouterLink to="/admin/users" class="text-blue-600 underline"
         >Manage Clients</RouterLink
       >
+      <RouterLink to="/admin/results" class="text-blue-600 underline"
+        >View Results</RouterLink
+      >
     </div>
   </div>
 </template>

--- a/src/views/admin/Results.vue
+++ b/src/views/admin/Results.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import { db } from '../../firebase'
+import { ref as dbRef, get } from 'firebase/database'
+import { useQuestionnaireStore } from '../../stores/questionnaires'
+
+const questionnaires = ref([])
+const selectedQuestionnaire = ref('')
+const responses = ref([])
+const qStore = useQuestionnaireStore()
+
+onMounted(async () => {
+  const qSnap = await get(dbRef(db, 'questionnaires'))
+  questionnaires.value = qSnap.exists()
+    ? Object.entries(qSnap.val()).map(([id, v]) => ({ id, ...v }))
+    : []
+})
+
+async function load() {
+  if (!selectedQuestionnaire.value) return
+  await qStore.fetchOne(selectedQuestionnaire.value)
+  const rSnap = await get(dbRef(db, 'responses'))
+  const all = rSnap.exists()
+    ? Object.entries(rSnap.val()).map(([id, v]) => ({ id, ...v }))
+    : []
+  responses.value = all.filter(
+    (r) => r.questionnaireId === selectedQuestionnaire.value && r.submittedAt
+  )
+}
+
+const aggregated = computed(() => {
+  const map = {}
+  for (const r of responses.value) {
+    if (!r.answers) continue
+    for (const [qid, ans] of Object.entries(r.answers)) {
+      const val = typeof ans === 'object' && ans !== null && 'value' in ans ? ans.value : ans
+      if (!map[qid]) map[qid] = {}
+      map[qid][val] = (map[qid][val] || 0) + 1
+    }
+  }
+  return map
+})
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Results</h1>
+    <div class="max-w-xl grid gap-4 sm:grid-cols-2">
+      <div>
+        <label class="block text-sm mb-1">Questionnaire</label>
+        <select
+          v-model="selectedQuestionnaire"
+          @change="load"
+          class="border p-2 rounded w-full"
+        >
+          <option value="" disabled>Select...</option>
+          <option v-for="q in questionnaires" :key="q.id" :value="q.id">{{ q.title }}</option>
+        </select>
+      </div>
+    </div>
+
+    <div v-if="selectedQuestionnaire" class="mt-8">
+      <h2 class="text-xl font-semibold mb-4">Aggregated Responses</h2>
+      <div v-if="responses.length === 0" class="text-slate-600">No responses yet.</div>
+      <div v-for="q in qStore.questions" :key="q.id" class="mb-6">
+        <h3 class="font-medium mb-2">{{ q.prompt }}</h3>
+        <ul class="pl-4 list-disc">
+          <li v-for="(count, val) in aggregated[q.id] || {}" :key="val">{{ val }}: {{ count }}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add admin Results view to aggregate questionnaire responses
- Link to Results from admin dashboard and top navigation
- Register new `/admin/results` route

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b49195a894832e8ce1030e51b412cf