### PR TITLE
Add email-based questionnaire flow and results page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,7 +4,7 @@ import { useUserStore } from '../stores/user'
 import Questionnaires from '../views/Questionnaires.vue'
 import QuestionnaireRunner from '../views/QuestionnaireRunner.vue'
 import Login from '../views/Login.vue'
-import Register from '../views/Register.vue'
+import Results from '../views/Results.vue'
 import AdminDashboard from '../views/admin/Dashboard.vue'
 import AdminQuestionnaire from '../views/admin/QuestionnaireBuilder.vue'
 import AdminResponses from '../views/admin/Responses.vue'
@@ -15,7 +15,7 @@ const routes = [
   { path: '/', name: 'questionnaires', component: Questionnaires },
   { path: '/run/:id', name: 'run', component: QuestionnaireRunner },
   { path: '/login', name: 'login', component: Login },
-  { path: '/register', name: 'register', component: Register },
+  { path: '/results', name: 'results', component: Results },
   {
     path: '/admin',
     name: 'admin-dashboard',

--- a/src/views/QuestionnaireRunner.vue
+++ b/src/views/QuestionnaireRunner.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, computed } from 'vue'
+import { onMounted, computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useQuestionnaireStore } from '../stores/questionnaires'
 import { useResponseStore } from '../stores/responses'
@@ -9,14 +9,28 @@ const route = useRoute()
 const qStore = useQuestionnaireStore()
 const rStore = useResponseStore()
 const userStore = useUserStore()
+const email = ref(route.query.email || '')
+const started = ref(false)
 
 onMounted(async () => {
   await qStore.fetchOne(route.params.id)
-  await rStore.start(route.params.id)
+  if (userStore.isAdmin) {
+    await rStore.start(route.params.id, userStore.profile?.email || '')
+    started.value = true
+  } else if (email.value) {
+    await rStore.start(route.params.id, email.value)
+    started.value = true
+  }
 })
 
-function saveAnswer(id, value) {
-  rStore.save(id, value)
+function begin() {
+  if (!email.value) return
+  rStore.start(route.params.id, email.value)
+  started.value = true
+}
+
+function saveAnswer(id, value, adminOnly) {
+  rStore.save(id, value, adminOnly)
 }
 
 function submit() {
@@ -30,32 +44,41 @@ const visibleSections = computed(() =>
 
 <template>
   <div class="p-4" v-if="qStore.current">
-    <h1 class="text-2xl font-bold mb-4">{{ qStore.current.title }}</h1>
-    <div
-      v-for="section in visibleSections"
-      :key="section.id"
-      class="mb-6"
-    >
-      <h2 class="font-semibold mb-2">{{ section.title }}</h2>
-      <div
-        v-for="question in qStore.questionsBySection(section.id)"
-        :key="question.id"
-        class="mb-3"
-      >
-        <label class="block mb-1">{{ question.prompt }}</label>
-        <input
-          type="text"
-          class="border rounded w-full p-2"
-          v-model="rStore.answers[question.id]"
-          @input="saveAnswer(question.id, rStore.answers[question.id])"
-        />
-      </div>
+    <div v-if="!started && !userStore.isAdmin" class="mb-4 max-w-sm">
+      <label class="block mb-1">Email</label>
+      <input v-model="email" type="email" class="border p-2 rounded w-full mb-2" />
+      <button class="bg-blue-600 text-white px-4 py-2 rounded" @click="begin">
+        Start
+      </button>
     </div>
-    <button
-      class="bg-blue-600 text-white px-4 py-2 rounded"
-      @click="submit"
-    >
-      Submit
-    </button>
+    <div v-else>
+      <h1 class="text-2xl font-bold mb-4">{{ qStore.current.title }}</h1>
+      <div
+        v-for="section in visibleSections"
+        :key="section.id"
+        class="mb-6"
+      >
+        <h2 class="font-semibold mb-2">{{ section.title }}</h2>
+        <div
+          v-for="question in qStore.questionsBySection(section.id)"
+          :key="question.id"
+          class="mb-3"
+        >
+          <label class="block mb-1">{{ question.prompt }}</label>
+          <input
+            type="text"
+            class="border rounded w-full p-2"
+            :value="section.adminOnly ? rStore.adminAnswers[question.id] : rStore.answers[question.id]"
+            @input="saveAnswer(question.id, $event.target.value, section.adminOnly)"
+          />
+        </div>
+      </div>
+      <button
+        class="bg-blue-600 text-white px-4 py-2 rounded"
+        @click="submit"
+      >
+        Submit
+      </button>
+    </div>
   </div>
 </template>

--- a/src/views/Questionnaires.vue
+++ b/src/views/Questionnaires.vue
@@ -1,20 +1,54 @@
 <script setup>
-import { onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useQuestionnaireStore } from '../stores/questionnaires'
 import { RouterLink } from 'vue-router'
+import { db } from '../firebase'
+import { ref as dbRef, get } from 'firebase/database'
 
 const qStore = useQuestionnaireStore()
+const email = ref('')
+const statuses = ref({})
+
 onMounted(() => qStore.fetchPublished())
+
+async function loadStatuses() {
+  if (!email.value) return
+  const snap = await get(dbRef(db, 'responses'))
+  const all = snap.exists()
+    ? Object.entries(snap.val()).map(([id, v]) => ({ id, ...v }))
+    : []
+  const filtered = all.filter((r) => r.customerEmail === email.value)
+  const map = {}
+  for (const r of filtered) {
+    map[r.questionnaireId] =
+      r.adminAnswers && Object.keys(r.adminAnswers).length > 0 ? 'admin' : 'customer'
+  }
+  statuses.value = map
+}
 </script>
 
 <template>
   <div class="p-4">
     <h1 class="text-2xl font-bold mb-4">Start Questionnaire</h1>
+    <div class="mb-4 max-w-sm">
+      <label class="block mb-1">Email</label>
+      <input v-model="email" type="email" class="border p-2 rounded w-full mb-2" />
+      <div class="flex items-center gap-4">
+        <button class="bg-blue-600 text-white px-4 py-2 rounded" @click="loadStatuses">
+          Load
+        </button>
+        <RouterLink to="/results" class="text-blue-600 underline">Your Results</RouterLink>
+      </div>
+    </div>
     <ul>
       <li v-for="q in qStore.published" :key="q.id" class="mb-2">
-        <RouterLink :to="`/run/${q.id}`" class="text-blue-600 underline">
+        <RouterLink
+          :to="`/run/${q.id}?email=${encodeURIComponent(email)}`"
+          class="text-blue-600 underline"
+        >
           {{ q.title }}
         </RouterLink>
+        <span class="ml-2 text-sm text-slate-600">{{ statuses[q.id] || 'none' }}</span>
       </li>
     </ul>
   </div>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -1,0 +1,81 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { db } from '../firebase'
+import { ref as dbRef, get } from 'firebase/database'
+import { useQuestionnaireStore } from '../stores/questionnaires'
+import jsPDF from 'jspdf'
+
+const email = ref('')
+const responses = ref([])
+const questionnaires = ref({})
+const qStore = useQuestionnaireStore()
+
+onMounted(async () => {
+  const qSnap = await get(dbRef(db, 'questionnaires'))
+  questionnaires.value = qSnap.exists() ? qSnap.val() : {}
+})
+
+function titleOf(id) {
+  return questionnaires.value[id]?.title || id
+}
+
+async function load() {
+  if (!email.value) return
+  const snap = await get(dbRef(db, 'responses'))
+  const all = snap.exists()
+    ? Object.entries(snap.val()).map(([id, v]) => ({ id, ...v }))
+    : []
+  responses.value = all.filter((r) => r.customerEmail === email.value && r.submittedAt)
+}
+
+async function print(r) {
+  await qStore.fetchOne(r.questionnaireId)
+  const doc = new jsPDF()
+  let y = 10
+  doc.setFontSize(16)
+  doc.text(titleOf(r.questionnaireId), 10, y)
+  y += 10
+  doc.setFontSize(12)
+  for (const section of qStore.sections) {
+    doc.setFont(undefined, 'bold')
+    doc.text(section.title, 10, y)
+    y += 8
+    doc.setFont(undefined, 'normal')
+    for (const q of qStore.questionsBySection(section.id)) {
+      const source = section.adminOnly ? r.adminAnswers || {} : r.answers || {}
+      const ans = source[q.id]?.value || source[q.id] || ''
+      const line = `${q.prompt}: ${ans}`
+      const lines = doc.splitTextToSize(line, 190)
+      for (const l of lines) {
+        if (y > 280) {
+          doc.addPage()
+          y = 10
+        }
+        doc.text(l, 10, y)
+        y += 7
+      }
+    }
+    y += 4
+  }
+  doc.save('response.pdf')
+}
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Your Results</h1>
+    <div class="mb-4 max-w-sm">
+      <label class="block mb-1">Email</label>
+      <input v-model="email" type="email" class="border p-2 rounded w-full mb-2" />
+      <button class="bg-blue-600 text-white px-4 py-2 rounded" @click="load">
+        Load
+      </button>
+    </div>
+    <ul>
+      <li v-for="r in responses" :key="r.id" class="mb-2 flex justify-between items-center">
+        <span>{{ titleOf(r.questionnaireId) }}</span>
+        <button class="text-blue-600 underline" @click="print(r)">PDF</button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/src/views/admin/Responses.vue
+++ b/src/views/admin/Responses.vue
@@ -29,7 +29,7 @@ async function viewResponse(r) {
           <th class="p-2 border">ID</th>
           <th class="p-2 border">Questionnaire</th>
           <th class="p-2 border">User</th>
-          <th class="p-2 border">Submitted</th>
+          <th class="p-2 border">Status</th>
           <th class="p-2 border">Actions</th>
         </tr>
       </thead>
@@ -38,7 +38,15 @@ async function viewResponse(r) {
           <td class="p-2 border">{{ r.id }}</td>
           <td class="p-2 border">{{ r.questionnaireId }}</td>
           <td class="p-2 border">{{ r.userId }}</td>
-          <td class="p-2 border">{{ r.submittedAt ? new Date(r.submittedAt).toLocaleDateString() : 'Draft' }}</td>
+          <td class="p-2 border">
+            {{
+              r.adminAnswers && Object.keys(r.adminAnswers).length > 0
+                ? 'admin'
+                : r.submittedAt
+                ? 'customer'
+                : 'none'
+            }}
+          </td>
           <td class="p-2 border"><button class="text-blue-600 underline" @click="viewResponse(r)">View</button></td>
         </tr>
       </tbody>
@@ -51,7 +59,11 @@ async function viewResponse(r) {
         <ul class="pl-4 list-disc">
           <li v-for="q in qStore.questionsBySection(section.id)" :key="q.id">
             <strong>{{ q.prompt }}:</strong>
-            {{ selected.answers?.[q.id]?.value || selected.answers?.[q.id] || '' }}
+            {{
+              section.adminOnly
+                ? selected.adminAnswers?.[q.id]?.value || selected.adminAnswers?.[q.id] || ''
+                : selected.answers?.[q.id]?.value || selected.answers?.[q.id] || ''
+            }}
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- require email to start questionnaire and store customer/admin answers separately
- list questionnaires with completion status and provide PDF results page
- expose response status in admin panel

## Testing
- `npm install sweetalert2`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b52d6d06e4832ea2f9b29d38d92eac