### PR TITLE
Enforce account registration and fix admin logout visibility

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,15 @@
 <script setup>
 import { RouterLink, RouterView } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useUserStore } from './stores/user'
 
 const userStore = useUserStore()
+const router = useRouter()
+
+async function logout() {
+  await userStore.logout()
+  router.push('/login')
+}
 </script>
 
 <template>
@@ -41,7 +48,7 @@ const userStore = useUserStore()
         >
         <button
           v-else
-          @click="userStore.logout"
+          @click="logout"
           class="hover:underline"
         >Logout</button>
         <span v-if="userStore.authUser">{{ userStore.profile?.email }}</span>

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -57,8 +57,10 @@ export const useUserStore = defineStore('user', () => {
     await fetchProfile(cred.user.uid)
   }
 
-  function logout() {
-    return signOut(auth)
+  async function logout() {
+    await signOut(auth)
+    authUser.value = null
+    profile.value = null
   }
 
   const isAdmin = computed(() => profile.value?.role === 'admin')

--- a/src/views/QuestionnaireRunner.vue
+++ b/src/views/QuestionnaireRunner.vue
@@ -48,11 +48,21 @@ async function begin() {
       return
     }
   } else if (!userSnap.exists()) {
-    Swal.fire(
-      'Info',
-      'Nu există cont pentru acest email. Continuați ca invitat.',
-      'info'
-    )
+    const { value: password } = await Swal.fire({
+      title: 'Creați cont',
+      text: 'Nu există cont pentru acest email. Creați o parolă pentru a continua.',
+      input: 'password',
+      inputPlaceholder: 'Parolă',
+      inputAttributes: { autocapitalize: 'off', autocomplete: 'new-password' },
+      showCancelButton: true
+    })
+    if (!password) return
+    try {
+      await userStore.register(email.value, password)
+    } catch (e) {
+      Swal.fire('Înregistrare eșuată', e.message, 'error')
+      return
+    }
   }
 
   await rStore.start(route.params.id, email.value)


### PR DESCRIPTION
## Summary
- Require users to register when starting a questionnaire with an unrecognized email
- Clear user state on logout and redirect to login to hide admin navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5336ba6ac832eb030c1ee1cbf2750