### PR TITLE
feat: improve questionnaire flow and admin ro

### DIFF
--- a/src/stores/responses.js
+++ b/src/stores/responses.js
@@ -7,13 +7,10 @@ import {
   set,
   update
 } from 'firebase/database'
-import jsPDF from 'jspdf'
 import { useUserStore } from './user'
-import { useQuestionnaireStore } from './questionnaires'
 
 export const useResponseStore = defineStore('responses', () => {
   const userStore = useUserStore()
-  const qStore = useQuestionnaireStore()
   const responseId = ref(null)
   const customerEmail = ref('')
   const answers = ref({})
@@ -57,42 +54,6 @@ export const useResponseStore = defineStore('responses', () => {
     await update(dbRef(db, `responses/${responseId.value}`), {
       submittedAt: Date.now()
     })
-
-    const doc = new jsPDF()
-    let y = 10
-    doc.setFontSize(16)
-    if (qStore.current) {
-      doc.text(qStore.current.title || 'Response', 10, y)
-      y += 10
-    }
-    doc.setFontSize(12)
-    for (const section of qStore.sections) {
-      if (section.adminOnly && !userStore.isAdmin) continue
-      if (y > 270) {
-        doc.addPage()
-        y = 10
-      }
-      doc.setFont(undefined, 'bold')
-      doc.text(section.title, 10, y)
-      y += 8
-      doc.setFont(undefined, 'normal')
-      for (const q of qStore.questionsBySection(section.id)) {
-        const store = section.adminOnly ? adminAnswers.value : answers.value
-        const ans = store[q.id] ?? ''
-        const line = `${q.prompt}: ${ans}`
-        const lines = doc.splitTextToSize(line, 190)
-        for (const l of lines) {
-          if (y > 280) {
-            doc.addPage()
-            y = 10
-          }
-          doc.text(l, 10, y)
-          y += 7
-        }
-      }
-      y += 4
-    }
-    doc.save('response.pdf')
   }
 
   return {

--- a/src/views/QuestionnaireRunner.vue
+++ b/src/views/QuestionnaireRunner.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { onMounted, computed, ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useQuestionnaireStore } from '../stores/questionnaires'
 import { useResponseStore } from '../stores/responses'
 import { useUserStore } from '../stores/user'
@@ -9,6 +9,7 @@ import { db } from '../firebase'
 import { ref as dbRef, query, orderByChild, equalTo, get } from 'firebase/database'
 
 const route = useRoute()
+const router = useRouter()
 const qStore = useQuestionnaireStore()
 const rStore = useResponseStore()
 const userStore = useUserStore()
@@ -73,8 +74,10 @@ function saveAnswer(id, value, adminOnly) {
   rStore.save(id, value, adminOnly)
 }
 
-function submit() {
-  rStore.submit()
+async function submit() {
+  await rStore.submit()
+  await Swal.fire('Chestionar salvat', 'Puteți imprima sau modifica din lista de chestionare.', 'success')
+  router.push({ name: 'questionnaires' })
 }
 
 const visibleSections = computed(() =>

--- a/src/views/Questionnaires.vue
+++ b/src/views/Questionnaires.vue
@@ -27,7 +27,7 @@ async function loadStatuses() {
 }
 
 function statusText(v) {
-  if (v === 'admin') return 'admin'
+  if (v === 'admin') return 'administrator'
   if (v === 'customer') return 'completat'
   return 'necompletat'
 }

--- a/src/views/admin/Dashboard.vue
+++ b/src/views/admin/Dashboard.vue
@@ -17,11 +17,11 @@ onMounted(async () => {
 
 <template>
   <div class="p-4">
-    <h1 class="text-2xl font-bold mb-4">Admin Dashboard</h1>
+    <h1 class="text-2xl font-bold mb-4">Panou administrare</h1>
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <div class="p-4 rounded shadow flex items-center justify-between text-white bg-emerald-500">
         <div>
-          <div class="text-sm">Questionnaires</div>
+          <div class="text-sm">Chestionare</div>
           <div class="text-3xl font-bold">{{ counts.questionnaires }}</div>
         </div>
         <svg
@@ -45,7 +45,7 @@ onMounted(async () => {
 
       <div class="p-4 rounded shadow flex items-center justify-between text-white bg-rose-500">
         <div>
-          <div class="text-sm">Responses</div>
+          <div class="text-sm">Răspunsuri</div>
           <div class="text-3xl font-bold">{{ counts.responses }}</div>
         </div>
         <svg
@@ -64,7 +64,7 @@ onMounted(async () => {
 
       <div class="p-4 rounded shadow flex items-center justify-between text-white bg-amber-500">
         <div>
-          <div class="text-sm">Clients</div>
+          <div class="text-sm">Clienți</div>
           <div class="text-3xl font-bold">{{ counts.users }}</div>
         </div>
         <svg
@@ -81,13 +81,13 @@ onMounted(async () => {
     </div>
     <div class="mt-4 space-x-4">
       <RouterLink to="/admin/questionnaires" class="text-blue-600 underline"
-        >New Questionnaire</RouterLink
+        >Chestionar nou</RouterLink
       >
       <RouterLink to="/admin/users" class="text-blue-600 underline"
-        >Manage Clients</RouterLink
+        >Gestionează clienți</RouterLink
       >
       <RouterLink to="/admin/results" class="text-blue-600 underline"
-        >View Results</RouterLink
+        >Vezi rezultate</RouterLink
       >
     </div>
   </div>

--- a/src/views/admin/QuestionnaireBuilder.vue
+++ b/src/views/admin/QuestionnaireBuilder.vue
@@ -42,22 +42,22 @@ async function saveQuestionnaire() {
       ...questionnaire.value,
       updatedAt: Date.now()
     })
-    Swal.fire('Saved', 'Questionnaire updated', 'success')
+    Swal.fire('Salvat', 'Chestionar actualizat', 'success')
   } else {
     const newRef = push(dbRef(db, 'questionnaires'))
     await set(newRef, { ...questionnaire.value, createdAt: Date.now(), updatedAt: Date.now() })
-    Swal.fire('Created', 'Questionnaire created', 'success')
+    Swal.fire('Creat', 'Chestionar creat', 'success')
     router.replace({ name: 'admin-questionnaire', params: { id: newRef.key } })
   }
 }
 
 async function addSection() {
   if (!route.params.id) {
-    Swal.fire('Save first', 'Please save the questionnaire before adding sections', 'info')
+    Swal.fire('Salvați mai întâi', 'Vă rugăm să salvați chestionarul înainte de a adăuga secțiuni', 'info')
     return
   }
   if (!newSectionTitle.value) {
-    Swal.fire('Missing title', 'Section title is required', 'warning')
+    Swal.fire('Titlu lipsă', 'Titlul secțiunii este necesar', 'warning')
     return
   }
   const newRef = push(dbRef(db, 'sections'))
@@ -70,7 +70,7 @@ async function addSection() {
   sections.value.push({ id: newRef.key, title: newSectionTitle.value, order: sections.value.length + 1, adminOnly: newSectionAdminOnly.value })
   newSectionTitle.value = ''
   newSectionAdminOnly.value = false
-  Swal.fire('Added', 'Section added', 'success')
+  Swal.fire('Adăugat', 'Secțiune adăugată', 'success')
 }
 
 function questionsBySection(sectionId) {
@@ -79,12 +79,12 @@ function questionsBySection(sectionId) {
 
 async function addQuestion(sectionId) {
   if (!route.params.id) {
-    Swal.fire('Save first', 'Please save the questionnaire before adding questions', 'info')
+    Swal.fire('Salvați mai întâi', 'Vă rugăm să salvați chestionarul înainte de a adăuga întrebări', 'info')
     return
   }
   const prompt = newQuestions.value[sectionId]
   if (!prompt) {
-    Swal.fire('Missing prompt', 'Question prompt is required', 'warning')
+    Swal.fire('Întrebare lipsă', 'Enunțul întrebării este necesar', 'warning')
     return
   }
   const newRef = push(dbRef(db, 'questions'))
@@ -102,7 +102,7 @@ async function addQuestion(sectionId) {
     type: 'text'
   })
   newQuestions.value[sectionId] = ''
-  Swal.fire('Added', 'Question added', 'success')
+  Swal.fire('Adăugat', 'Întrebare adăugată', 'success')
 }
 
 async function updateSectionAdmin(section) {
@@ -112,10 +112,10 @@ async function updateSectionAdmin(section) {
 async function deleteQuestionnaire() {
   if (!route.params.id) return
   const confirm = await Swal.fire({
-    title: 'Delete questionnaire?',
-    text: 'This will remove all sections and questions',
+    title: 'Șterge chestionarul?',
+    text: 'Aceasta va elimina toate secțiunile și întrebările',
     showCancelButton: true,
-    confirmButtonText: 'Delete',
+    confirmButtonText: 'Șterge',
     icon: 'warning'
   })
   if (!confirm.isConfirmed) return
@@ -126,58 +126,58 @@ async function deleteQuestionnaire() {
   for (const q of questions.value) {
     await remove(dbRef(db, `questions/${q.id}`))
   }
-  Swal.fire('Deleted', 'Questionnaire deleted', 'success')
+  Swal.fire('Șters', 'Chestionar șters', 'success')
   router.push('/admin')
 }
 </script>
 
 <template>
   <div class="p-4">
-    <h1 class="text-xl font-bold mb-4">Questionnaire Builder</h1>
+    <h1 class="text-xl font-bold mb-4">Editor chestionar</h1>
     <div class="mb-4">
-      <label class="block mb-1">Title</label>
+      <label class="block mb-1">Titlu</label>
       <input v-model="questionnaire.title" class="border rounded p-2 w-full" />
     </div>
     <div class="mb-4">
-      <label class="block mb-1">Description</label>
+      <label class="block mb-1">Descriere</label>
       <textarea v-model="questionnaire.description" class="border rounded p-2 w-full" />
     </div>
     <div class="mb-4">
-      <label class="block mb-1">Status</label>
+      <label class="block mb-1">Stare</label>
       <select v-model="questionnaire.status" class="border rounded p-2 w-full">
-        <option value="draft">Draft</option>
-        <option value="published">Published</option>
+        <option value="draft">Schiță</option>
+        <option value="published">Publicat</option>
       </select>
     </div>
     <div class="flex gap-2">
-      <button class="bg-green-600 text-white px-4 py-2 rounded" @click="saveQuestionnaire">Save</button>
-      <button v-if="route.params.id" class="bg-red-600 text-white px-4 py-2 rounded" @click="deleteQuestionnaire">Delete</button>
+      <button class="bg-green-600 text-white px-4 py-2 rounded" @click="saveQuestionnaire">Salvează</button>
+      <button v-if="route.params.id" class="bg-red-600 text-white px-4 py-2 rounded" @click="deleteQuestionnaire">Șterge</button>
     </div>
 
     <div class="mt-8">
-      <h2 class="font-semibold mb-2">Sections</h2>
+      <h2 class="font-semibold mb-2">Secțiuni</h2>
       <div v-for="s in sections" :key="s.id" class="mb-4 border rounded p-2">
         <div class="flex items-center justify-between mb-2">
           <h3 class="font-medium">{{ s.title }}</h3>
           <label class="flex items-center text-sm gap-1">
             <input type="checkbox" v-model="s.adminOnly" @change="updateSectionAdmin(s)" />
-            Admin only
+            Doar admin
           </label>
         </div>
         <ul class="mb-2 pl-4 list-disc">
           <li v-for="q in questionsBySection(s.id)" :key="q.id" class="mb-1">{{ q.prompt }}</li>
         </ul>
         <div class="flex gap-2">
-          <input v-model="newQuestions[s.id]" placeholder="New question prompt" class="border p-2 flex-1" />
-          <button class="bg-blue-600 text-white px-3 rounded" @click="addQuestion(s.id)">Add</button>
+          <input v-model="newQuestions[s.id]" placeholder="Enunț întrebare nouă" class="border p-2 flex-1" />
+          <button class="bg-blue-600 text-white px-3 rounded" @click="addQuestion(s.id)">Adaugă</button>
         </div>
       </div>
       <div class="flex gap-2 mt-4 items-center">
-        <input v-model="newSectionTitle" placeholder="New section title" class="border p-2 flex-1" />
+        <input v-model="newSectionTitle" placeholder="Titlu secțiune nouă" class="border p-2 flex-1" />
         <label class="flex items-center text-sm gap-1">
-          <input type="checkbox" v-model="newSectionAdminOnly" /> Admin only
+          <input type="checkbox" v-model="newSectionAdminOnly" /> Doar admin
         </label>
-        <button class="bg-blue-600 text-white px-3 rounded" @click="addSection">Add Section</button>
+        <button class="bg-blue-600 text-white px-3 rounded" @click="addSection">Adaugă secțiune</button>
       </div>
     </div>
   </div>

--- a/src/views/admin/Responses.vue
+++ b/src/views/admin/Responses.vue
@@ -22,15 +22,15 @@ async function viewResponse(r) {
 
 <template>
   <div class="p-4">
-    <h1 class="text-2xl font-bold mb-4">Responses</h1>
+    <h1 class="text-2xl font-bold mb-4">Răspunsuri</h1>
     <table class="min-w-full text-left">
       <thead>
         <tr>
           <th class="p-2 border">ID</th>
-          <th class="p-2 border">Questionnaire</th>
-          <th class="p-2 border">User</th>
-          <th class="p-2 border">Status</th>
-          <th class="p-2 border">Actions</th>
+          <th class="p-2 border">Chestionar</th>
+          <th class="p-2 border">Utilizator</th>
+          <th class="p-2 border">Stare</th>
+          <th class="p-2 border">Acțiuni</th>
         </tr>
       </thead>
       <tbody>
@@ -41,19 +41,19 @@ async function viewResponse(r) {
           <td class="p-2 border">
             {{
               r.adminAnswers && Object.keys(r.adminAnswers).length > 0
-                ? 'admin'
+                ? 'administrator'
                 : r.submittedAt
-                ? 'customer'
-                : 'none'
+                ? 'client'
+                : 'niciunul'
             }}
           </td>
-          <td class="p-2 border"><button class="text-blue-600 underline" @click="viewResponse(r)">View</button></td>
+          <td class="p-2 border"><button class="text-blue-600 underline" @click="viewResponse(r)">Vezi</button></td>
         </tr>
       </tbody>
     </table>
 
     <div v-if="selected" class="mt-6">
-      <h2 class="text-xl font-bold mb-4">Response {{ selected.id }}</h2>
+      <h2 class="text-xl font-bold mb-4">Răspuns {{ selected.id }}</h2>
       <div v-for="section in qStore.sections" :key="section.id" class="mb-4">
         <h3 class="font-semibold mb-2">{{ section.title }}</h3>
         <ul class="pl-4 list-disc">

--- a/src/views/admin/Results.vue
+++ b/src/views/admin/Results.vue
@@ -44,24 +44,24 @@ const aggregated = computed(() => {
 
 <template>
   <div class="p-4">
-    <h1 class="text-2xl font-bold mb-4">Results</h1>
+    <h1 class="text-2xl font-bold mb-4">Rezultate</h1>
     <div class="max-w-xl grid gap-4 sm:grid-cols-2">
       <div>
-        <label class="block text-sm mb-1">Questionnaire</label>
+        <label class="block text-sm mb-1">Chestionar</label>
         <select
           v-model="selectedQuestionnaire"
           @change="load"
           class="border p-2 rounded w-full"
         >
-          <option value="" disabled>Select...</option>
+          <option value="" disabled>Selectează...</option>
           <option v-for="q in questionnaires" :key="q.id" :value="q.id">{{ q.title }}</option>
         </select>
       </div>
     </div>
 
     <div v-if="selectedQuestionnaire" class="mt-8">
-      <h2 class="text-xl font-semibold mb-4">Aggregated Responses</h2>
-      <div v-if="responses.length === 0" class="text-slate-600">No responses yet.</div>
+      <h2 class="text-xl font-semibold mb-4">Răspunsuri agregate</h2>
+      <div v-if="responses.length === 0" class="text-slate-600">Niciun răspuns deocamdată.</div>
       <div v-for="q in qStore.questions" :key="q.id" class="mb-6">
         <h3 class="font-medium mb-2">{{ q.prompt }}</h3>
         <ul class="pl-4 list-disc">

--- a/src/views/admin/Users.vue
+++ b/src/views/admin/Users.vue
@@ -21,13 +21,13 @@ onMounted(loadUsers)
 
 <template>
   <div class="p-4">
-    <h1 class="text-2xl font-bold mb-4">Users</h1>
+    <h1 class="text-2xl font-bold mb-4">Utilizatori</h1>
     <table class="min-w-full text-left">
       <thead>
         <tr>
           <th class="p-2 border">ID</th>
           <th class="p-2 border">Email</th>
-          <th class="p-2 border">Role</th>
+          <th class="p-2 border">Rol</th>
         </tr>
       </thead>
       <tbody>
@@ -36,8 +36,8 @@ onMounted(loadUsers)
           <td class="p-2 border">{{ u.email }}</td>
           <td class="p-2 border">
             <select v-model="u.role" @change="changeRole(u, u.role)" class="border p-1">
-              <option value="customer">customer</option>
-              <option value="admin">admin</option>
+              <option value="customer">client</option>
+              <option value="admin">administrator</option>
             </select>
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- redirect to list after questionnaire submit with confirmation and without auto PDF download
- translate admin interface components into Romanian

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5354a5f9c832ebe9de3ebc457066a