### PR TITLE
Split questionnaire start options for resume and new

### DIFF
--- a/src/views/Questionnaires.vue
+++ b/src/views/Questionnaires.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useQuestionnaireStore } from '../stores/questionnaires'
 import { RouterLink } from 'vue-router'
 import { db } from '../firebase'
@@ -8,6 +8,11 @@ import { ref as dbRef, get } from 'firebase/database'
 const qStore = useQuestionnaireStore()
 const email = ref('')
 const statuses = ref({})
+const mode = ref(null)
+
+const incomplete = computed(() =>
+  qStore.published.filter((q) => !statuses.value[q.id])
+)
 
 onMounted(() => qStore.fetchPublished())
 
@@ -35,36 +40,84 @@ function statusText(v) {
 
 <template>
   <div class="p-4">
-    <h1 class="text-2xl font-bold mb-4">Începe chestionarul</h1>
-    <div class="mb-4 max-w-sm">
-      <label class="block mb-1">Email</label>
-      <input
-        v-model="email"
-        type="email"
-        class="border border-gray-300 rounded w-full mb-2 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-      />
-      <div class="flex items-center gap-4">
+    <div v-if="!mode">
+      <h1 class="text-2xl font-bold mb-4">Începe chestionarul</h1>
+      <div class="flex flex-col gap-4 max-w-sm">
         <button
           class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-          @click="loadStatuses"
+          @click="mode = 'resume'"
         >
-          Încarcă
+          Reia/Vizualizează chestionar
         </button>
-        <RouterLink to="/results" class="text-blue-600 underline"
-          >Rezultatele tale</RouterLink
+        <button
+          class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
+          @click="mode = 'new'"
         >
+          Începe chestionar nou
+        </button>
       </div>
     </div>
-    <ul>
-      <li v-for="q in qStore.published" :key="q.id" class="mb-2">
-        <RouterLink
-          :to="`/run/${q.id}?email=${encodeURIComponent(email)}`"
-          class="text-blue-600 underline"
-        >
-          {{ q.title }}
-        </RouterLink>
-        <span class="ml-2 text-sm text-slate-600">{{ statusText(statuses[q.id]) }}</span>
-      </li>
-    </ul>
+    <div v-else>
+      <h1 class="text-2xl font-bold mb-4">
+        {{ mode === 'resume' ? 'Reia/Vizualizează chestionarul' : 'Începe chestionar nou' }}
+      </h1>
+      <div class="mb-4 max-w-sm">
+        <label class="block mb-1">Email</label>
+        <input
+          v-model="email"
+          type="email"
+          class="border border-gray-300 rounded w-full mb-2 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <div class="flex items-center gap-4">
+          <button
+            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+            @click="loadStatuses"
+          >
+            Încarcă
+          </button>
+          <RouterLink to="/results" class="text-blue-600 underline"
+            >Rezultatele tale</RouterLink
+          >
+        </div>
+      </div>
+      <div v-if="mode === 'resume'">
+        <table class="w-full max-w-xl text-left border">
+          <thead>
+            <tr class="border-b">
+              <th class="p-2">Chestionar</th>
+              <th class="p-2">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="q in qStore.published" :key="q.id" class="border-b last:border-b-0">
+              <td class="p-2">
+                <RouterLink
+                  :to="`/run/${q.id}?email=${encodeURIComponent(email)}`"
+                  class="text-blue-600 underline"
+                >
+                  {{ q.title }}
+                </RouterLink>
+              </td>
+              <td class="p-2 text-sm text-slate-600">
+                {{ statusText(statuses[q.id]) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div v-else>
+        <ul>
+          <li v-for="q in incomplete" :key="q.id" class="mb-2">
+            <RouterLink
+              :to="`/run/${q.id}?email=${encodeURIComponent(email)}`"
+              class="text-blue-600 underline"
+            >
+              {{ q.title }}
+            </RouterLink>
+          </li>
+        </ul>
+      </div>
+      <button class="mt-4 text-blue-600 underline" @click="mode = null">Înapoi</button>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Add mode state to display either existing or new questionnaires
- Provide buttons for "Reia/Vizualizează chestionar" and "Începe chestionar nou"
- Resume view shows tabular questionnaire list with statuses, new view filters unfinished questionnaires

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b536a84a68832e81e9dce558ed9276