### PR TITLE
Persist login and streamline questionnaire flows

### DIFF
--- a/src/stores/responses.js
+++ b/src/stores/responses.js
@@ -16,7 +16,8 @@ export const useResponseStore = defineStore('responses', () => {
   const answers = ref({})
   const adminAnswers = ref({})
 
-  async function start(questionnaireId, email) {
+  async function start(questionnaireId) {
+    const email = userStore.profile?.email || ''
     const resRef = push(dbRef(db, 'responses'))
     responseId.value = resRef.key
     customerEmail.value = email

--- a/src/views/QuestionnaireRunner.vue
+++ b/src/views/QuestionnaireRunner.vue
@@ -1,74 +1,28 @@
 <script setup>
-import { onMounted, computed, ref } from 'vue'
+import { onMounted, ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuestionnaireStore } from '../stores/questionnaires'
 import { useResponseStore } from '../stores/responses'
 import { useUserStore } from '../stores/user'
 import Swal from 'sweetalert2'
-import { db } from '../firebase'
-import { ref as dbRef, query, orderByChild, equalTo, get } from 'firebase/database'
 
 const route = useRoute()
 const router = useRouter()
 const qStore = useQuestionnaireStore()
 const rStore = useResponseStore()
 const userStore = useUserStore()
-const email = ref(route.query.email || '')
 const started = ref(false)
 
 onMounted(async () => {
   await qStore.fetchOne(route.params.id)
-  if (email.value) {
-    await begin()
-  }
-})
-
-async function begin() {
-  if (!email.value) {
-    Swal.fire('Email lipsă', 'Vă rugăm introduceți adresa de email.', 'warning')
+  if (!userStore.authUser) {
+    await Swal.fire('Autentificare necesară', 'Vă rugăm să vă conectați.', 'warning')
+    router.push({ name: 'login' })
     return
   }
-
-  const userSnap = await get(
-    query(dbRef(db, 'users'), orderByChild('email'), equalTo(email.value))
-  )
-
-  if (userSnap.exists() && !userStore.authUser) {
-    const { value: password } = await Swal.fire({
-      title: 'Parolă necesară',
-      input: 'password',
-      inputPlaceholder: 'Introduceți parola',
-      inputAttributes: { autocapitalize: 'off', autocomplete: 'new-password' },
-      showCancelButton: true
-    })
-    if (!password) return
-    try {
-      await userStore.login(email.value, password)
-    } catch (e) {
-      Swal.fire('Autentificare eșuată', e.message, 'error')
-      return
-    }
-  } else if (!userSnap.exists()) {
-    const { value: password } = await Swal.fire({
-      title: 'Creați cont',
-      text: 'Nu există cont pentru acest email. Creați o parolă pentru a continua.',
-      input: 'password',
-      inputPlaceholder: 'Parolă',
-      inputAttributes: { autocapitalize: 'off', autocomplete: 'new-password' },
-      showCancelButton: true
-    })
-    if (!password) return
-    try {
-      await userStore.register(email.value, password)
-    } catch (e) {
-      Swal.fire('Înregistrare eșuată', e.message, 'error')
-      return
-    }
-  }
-
-  await rStore.start(route.params.id, email.value)
+  await rStore.start(route.params.id)
   started.value = true
-}
+})
 
 function saveAnswer(id, value, adminOnly) {
   rStore.save(id, value, adminOnly)
@@ -87,56 +41,34 @@ const visibleSections = computed(() =>
 
 <template>
   <div class="p-4" v-if="qStore.current">
+  <div v-if="started">
+    <h1 class="text-2xl font-bold mb-4">{{ qStore.current.title }}</h1>
     <div
-      v-if="!started"
-      class="max-w-md mx-auto mt-4 shadow-lg rounded-lg overflow-hidden"
+      v-for="section in visibleSections"
+      :key="section.id"
+      class="mb-6"
     >
-      <div class="bg-slate-800 text-white text-center py-4 text-2xl font-bold">
-        Start chestionar
-      </div>
-      <div class="p-6 bg-white">
-        <label class="block mb-2 font-semibold">Email participant</label>
-        <input
-          v-model="email"
-          type="email"
-          class="w-full border border-gray-300 rounded px-3 py-2 mb-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        />
-        <button
-          class="w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-          @click="begin"
-        >
-          Începe
-        </button>
-      </div>
-    </div>
-    <div v-else>
-      <h1 class="text-2xl font-bold mb-4">{{ qStore.current.title }}</h1>
+      <h2 class="font-semibold mb-2">{{ section.title }}</h2>
       <div
-        v-for="section in visibleSections"
-        :key="section.id"
-        class="mb-6"
+        v-for="question in qStore.questionsBySection(section.id)"
+        :key="question.id"
+        class="mb-3"
       >
-        <h2 class="font-semibold mb-2">{{ section.title }}</h2>
-        <div
-          v-for="question in qStore.questionsBySection(section.id)"
-          :key="question.id"
-          class="mb-3"
-        >
-          <label class="block mb-1">{{ question.prompt }}</label>
-          <input
-            type="text"
-            class="border border-gray-300 rounded w-full p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            :value="section.adminOnly ? rStore.adminAnswers[question.id] : rStore.answers[question.id]"
-            @input="saveAnswer(question.id, $event.target.value, section.adminOnly)"
-          />
-        </div>
+        <label class="block mb-1">{{ question.prompt }}</label>
+        <input
+          type="text"
+          class="border border-gray-300 rounded w-full p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          :value="section.adminOnly ? rStore.adminAnswers[question.id] : rStore.answers[question.id]"
+          @input="saveAnswer(question.id, $event.target.value, section.adminOnly)"
+        />
       </div>
-      <button
-        class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-        @click="submit"
-      >
-        Trimite
-      </button>
     </div>
+    <button
+      class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+      @click="submit"
+    >
+      Trimite
+    </button>
   </div>
+</div>
 </template>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -1,18 +1,25 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed, watch } from 'vue'
 import { db } from '../firebase'
 import { ref as dbRef, get } from 'firebase/database'
 import { useQuestionnaireStore } from '../stores/questionnaires'
+import { useUserStore } from '../stores/user'
 import jsPDF from 'jspdf'
 
-const email = ref('')
 const responses = ref([])
 const questionnaires = ref({})
 const qStore = useQuestionnaireStore()
+const userStore = useUserStore()
+const email = computed(() => userStore.profile?.email || '')
 
 onMounted(async () => {
   const qSnap = await get(dbRef(db, 'questionnaires'))
   questionnaires.value = qSnap.exists() ? qSnap.val() : {}
+  if (email.value) load()
+})
+
+watch(() => email.value, (val) => {
+  if (val) load()
 })
 
 function titleOf(id) {
@@ -64,20 +71,6 @@ async function print(r) {
 <template>
   <div class="p-4">
     <h1 class="text-2xl font-bold mb-4">Rezultatele tale</h1>
-    <div class="mb-4 max-w-sm">
-      <label class="block mb-1">Email</label>
-      <input
-        v-model="email"
-        type="email"
-        class="border border-gray-300 rounded w-full mb-2 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-      />
-      <button
-        class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-        @click="load"
-      >
-        Încarcă
-      </button>
-    </div>
     <ul>
       <li
         v-for="r in responses"


### PR DESCRIPTION
## Summary
- Persist user profile and auth state in localStorage so sessions survive refreshes
- Start and resume questionnaires without entering email
- Load questionnaire results for the logged-in user automatically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b53f1b5888832eb833a295c8de9bf1