### PR TITLE
Fix navbar visibility before user login

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,27 +17,29 @@ async function logout() {
     <nav
       class="bg-slate-800 text-white p-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4 shadow"
     >
-      <RouterLink to="/" class="hover:underline font-semibold text-xl">
-        Fit Plan - Alexandra Brad PT
-      </RouterLink>
-      <RouterLink
-        to="/admin"
-        class="hover:underline"
-        v-if="userStore.isAdmin"
-        >Admin</RouterLink
-      >
-      <RouterLink
-        v-if="userStore.isAdmin"
-        to="/admin/questionnaires"
-        class="hover:underline"
-        >Add Questionnaire</RouterLink
-      >
-      <RouterLink
-        v-if="userStore.isAdmin"
-        to="/admin/results"
-        class="hover:underline"
-        >Results</RouterLink
-      >
+      <template v-if="userStore.authUser">
+        <RouterLink to="/" class="hover:underline font-semibold text-xl">
+          Fit Plan - Alexandra Brad PT
+        </RouterLink>
+        <RouterLink
+          to="/admin"
+          class="hover:underline"
+          v-if="userStore.isAdmin"
+          >Admin</RouterLink
+        >
+        <RouterLink
+          v-if="userStore.isAdmin"
+          to="/admin/questionnaires"
+          class="hover:underline"
+          >Add Questionnaire</RouterLink
+        >
+        <RouterLink
+          v-if="userStore.isAdmin"
+          to="/admin/results"
+          class="hover:underline"
+          >Results</RouterLink
+        >
+      </template>
 
       <div class="sm:ml-auto flex gap-4 items-center">
         <RouterLink

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -44,22 +44,25 @@ export const useUserStore = defineStore('user', () => {
     }
   }
 
-  onAuthStateChanged(auth, async (u) => {
-    authUser.value = u
-    if (u) {
-      localStorage.setItem(
-        'authUser',
-        JSON.stringify({ uid: u.uid, email: u.email })
-      )
-      await fetchProfile(u.uid)
-    } else {
-      profile.value = null
-      localStorage.removeItem('authUser')
-      localStorage.removeItem('profile')
-    }
-  })
+  async function initAuth() {
+    await ensureDefaultAdmin()
+    onAuthStateChanged(auth, async (u) => {
+      authUser.value = u
+      if (u) {
+        localStorage.setItem(
+          'authUser',
+          JSON.stringify({ uid: u.uid, email: u.email })
+        )
+        await fetchProfile(u.uid)
+      } else {
+        profile.value = null
+        localStorage.removeItem('authUser')
+        localStorage.removeItem('profile')
+      }
+    })
+  }
 
-  ensureDefaultAdmin()
+  initAuth()
 
   async function register(email, password) {
     const cred = await createUserWithEmailAndPassword(auth, email, password)


### PR DESCRIPTION
## Summary
- Hide navigation links unless a user is authenticated
- Initialize auth state only after ensuring default admin to avoid unintended navbar flashes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b58b89ab8c832ea2497aeaf35b9979