### PR TITLE
Improve questionnaire completion tracking and UI

### DIFF
--- a/src/views/QuestionnaireRunner.vue
+++ b/src/views/QuestionnaireRunner.vue
@@ -40,7 +40,7 @@ const visibleSections = computed(() =>
 </script>
 
 <template>
-  <div class="p-4" v-if="qStore.current">
+  <div class="p-4 max-w-2xl mx-auto" v-if="qStore.current">
   <div v-if="started">
     <h1 class="text-2xl font-bold mb-4">{{ qStore.current.title }}</h1>
     <div

--- a/src/views/Questionnaires.vue
+++ b/src/views/Questionnaires.vue
@@ -41,9 +41,12 @@ async function loadStatuses() {
   const map = {}
   const resp = {}
   for (const r of filtered) {
-    map[r.questionnaireId] =
-      r.adminAnswers && Object.keys(r.adminAnswers).length > 0 ? 'admin' : 'customer'
-    resp[r.questionnaireId] = r
+    const hasAdmin = r.adminAnswers && Object.keys(r.adminAnswers).length > 0
+    const hasCustomer = r.answers && Object.keys(r.answers).length > 0
+    if (hasAdmin || hasCustomer) {
+      map[r.questionnaireId] = hasAdmin ? 'admin' : 'customer'
+      resp[r.questionnaireId] = r
+    }
   }
   statuses.value = map
   responses.value = resp
@@ -136,7 +139,7 @@ async function print(r) {
                   Editează
                 </RouterLink>
                 <button
-                  v-if="responses[q.id]?.submittedAt"
+                  v-if="responses[q.id]"
                   class="px-2 py-1 bg-slate-200 hover:bg-slate-300 rounded text-sm"
                   @click="print(responses[q.id])"
                 >


### PR DESCRIPTION
## Summary
- treat questionnaires as filled once answers are saved
- allow printing any saved questionnaire
- limit questionnaire form width for better readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b590a8a688832ea935cc7a794b31d6