### PR TITLE
Enhance questionnaire builder, runner, and admin results

### DIFF
--- a/src/views/QuestionnaireRunner.vue
+++ b/src/views/QuestionnaireRunner.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { onMounted, ref, computed } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useQuestionnaireStore } from '../stores/questionnaires'
 import { useResponseStore } from '../stores/responses'
 import { useUserStore } from '../stores/user'
@@ -28,6 +28,15 @@ function saveAnswer(id, value, adminOnly) {
   rStore.save(id, value, adminOnly)
 }
 
+function toggleCheckbox(id, option, adminOnly) {
+  const source = adminOnly ? rStore.adminAnswers : rStore.answers
+  const current = Array.isArray(source[id]) ? [...source[id]] : []
+  const idx = current.indexOf(option)
+  if (idx > -1) current.splice(idx, 1)
+  else current.push(option)
+  saveAnswer(id, current, adminOnly)
+}
+
 async function submit() {
   await rStore.submit()
   await Swal.fire('Chestionar salvat', 'Puteți imprima sau modifica din lista de chestionare.', 'success')
@@ -40,35 +49,67 @@ const visibleSections = computed(() =>
 </script>
 
 <template>
-  <div class="p-4 max-w-2xl mx-auto" v-if="qStore.current">
-  <div v-if="started">
-    <h1 class="text-2xl font-bold mb-4">{{ qStore.current.title }}</h1>
-    <div
-      v-for="section in visibleSections"
-      :key="section.id"
-      class="mb-6"
-    >
-      <h2 class="font-semibold mb-2">{{ section.title }}</h2>
+  <div class="p-4" v-if="qStore.current">
+    <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow" v-if="started">
+      <RouterLink to="/questionnaires" class="text-blue-600 underline mb-4 inline-block">
+        &larr; Înapoi
+      </RouterLink>
+      <h1 class="text-2xl font-bold mb-4 text-center">{{ qStore.current.title }}</h1>
       <div
-        v-for="question in qStore.questionsBySection(section.id)"
-        :key="question.id"
-        class="mb-3"
+        v-for="section in visibleSections"
+        :key="section.id"
+        class="mb-6"
       >
-        <label class="block mb-1">{{ question.prompt }}</label>
-        <input
-          type="text"
-          class="border border-gray-300 rounded w-full p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          :value="section.adminOnly ? rStore.adminAnswers[question.id] : rStore.answers[question.id]"
-          @input="saveAnswer(question.id, $event.target.value, section.adminOnly)"
-        />
+        <h2 class="font-semibold mb-2">{{ section.title }}</h2>
+        <div
+          v-for="question in qStore.questionsBySection(section.id)"
+          :key="question.id"
+          class="mb-3"
+        >
+          <label class="block mb-1">{{ question.prompt }}</label>
+          <div v-if="question.type === 'radio'">
+            <div v-for="opt in question.options" :key="opt" class="mb-1">
+              <label class="inline-flex items-center gap-2">
+                <input
+                  type="radio"
+                  :name="question.id"
+                  :value="opt"
+                  :checked="(section.adminOnly ? rStore.adminAnswers[question.id] : rStore.answers[question.id]) === opt"
+                  @change="saveAnswer(question.id, opt, section.adminOnly)"
+                />
+                <span>{{ opt }}</span>
+              </label>
+            </div>
+          </div>
+          <div v-else-if="question.type === 'checkbox'">
+            <div v-for="opt in question.options" :key="opt" class="mb-1">
+              <label class="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  :value="opt"
+                  :checked="(section.adminOnly ? rStore.adminAnswers[question.id] : rStore.answers[question.id] || []).includes(opt)"
+                  @change="toggleCheckbox(question.id, opt, section.adminOnly)"
+                />
+                <span>{{ opt }}</span>
+              </label>
+            </div>
+          </div>
+          <div v-else>
+            <input
+              type="text"
+              class="border border-gray-300 rounded w-full p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              :value="section.adminOnly ? rStore.adminAnswers[question.id] : rStore.answers[question.id]"
+              @input="saveAnswer(question.id, $event.target.value, section.adminOnly)"
+            />
+          </div>
+        </div>
       </div>
+      <button
+        class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+        @click="submit"
+      >
+        Trimite
+      </button>
     </div>
-    <button
-      class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-      @click="submit"
-    >
-      Trimite
-    </button>
   </div>
-</div>
 </template>

--- a/src/views/Questionnaires.vue
+++ b/src/views/Questionnaires.vue
@@ -78,7 +78,8 @@ async function print(r) {
     doc.setFont(undefined, 'normal')
     for (const q of qStore.questionsBySection(section.id)) {
       const source = section.adminOnly ? r.adminAnswers || {} : r.answers || {}
-      const ans = source[q.id]?.value || source[q.id] || ''
+      const raw = source[q.id]?.value || source[q.id] || ''
+      const ans = Array.isArray(raw) ? raw.join(', ') : raw
       const line = `${q.prompt}: ${ans}`
       const lines = doc.splitTextToSize(line, 190)
       for (const l of lines) {

--- a/src/views/admin/Responses.vue
+++ b/src/views/admin/Responses.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
 import { db } from '../../firebase'
 import { ref as dbRef, get } from 'firebase/database'
 import { useQuestionnaireStore } from '../../stores/questionnaires'
@@ -22,8 +23,12 @@ async function viewResponse(r) {
 
 <template>
   <div class="p-4">
-    <h1 class="text-2xl font-bold mb-4">Răspunsuri</h1>
-    <table class="min-w-full text-left">
+    <div class="max-w-3xl mx-auto bg-white p-6 rounded shadow">
+      <RouterLink to="/admin" class="text-blue-600 underline mb-4 inline-block">
+        &larr; Înapoi
+      </RouterLink>
+      <h1 class="text-2xl font-bold mb-4 text-center">Răspunsuri</h1>
+      <table class="min-w-full text-left">
       <thead>
         <tr>
           <th class="p-2 border">ID</th>
@@ -50,22 +55,25 @@ async function viewResponse(r) {
           <td class="p-2 border"><button class="text-blue-600 underline" @click="viewResponse(r)">Vezi</button></td>
         </tr>
       </tbody>
-    </table>
+      </table>
 
-    <div v-if="selected" class="mt-6">
-      <h2 class="text-xl font-bold mb-4">Răspuns {{ selected.id }}</h2>
-      <div v-for="section in qStore.sections" :key="section.id" class="mb-4">
-        <h3 class="font-semibold mb-2">{{ section.title }}</h3>
-        <ul class="pl-4 list-disc">
-          <li v-for="q in qStore.questionsBySection(section.id)" :key="q.id">
-            <strong>{{ q.prompt }}:</strong>
-            {{
-              section.adminOnly
-                ? selected.adminAnswers?.[q.id]?.value || selected.adminAnswers?.[q.id] || ''
-                : selected.answers?.[q.id]?.value || selected.answers?.[q.id] || ''
-            }}
-          </li>
-        </ul>
+      <div v-if="selected" class="mt-6">
+        <h2 class="text-xl font-bold mb-4">Răspuns {{ selected.id }}</h2>
+        <div v-for="section in qStore.sections" :key="section.id" class="mb-4">
+          <h3 class="font-semibold mb-2">{{ section.title }}</h3>
+          <ul class="pl-4 list-disc">
+            <li v-for="q in qStore.questionsBySection(section.id)" :key="q.id">
+              <strong>{{ q.prompt }}:</strong>
+              {{
+                (() => {
+                  const source = section.adminOnly ? selected.adminAnswers || {} : selected.answers || {}
+                  const raw = source[q.id]?.value || source[q.id] || ''
+                  return Array.isArray(raw) ? raw.join(', ') : raw
+                })()
+              }}
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/src/views/admin/Results.vue
+++ b/src/views/admin/Results.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import jsPDF from 'jspdf'
 import { db } from '../../firebase'
 import { ref as dbRef, get } from 'firebase/database'
 import { useQuestionnaireStore } from '../../stores/questionnaires'
@@ -33,40 +35,119 @@ const aggregated = computed(() => {
   for (const r of responses.value) {
     if (!r.answers) continue
     for (const [qid, ans] of Object.entries(r.answers)) {
-      const val = typeof ans === 'object' && ans !== null && 'value' in ans ? ans.value : ans
+      const raw = typeof ans === 'object' && ans !== null && 'value' in ans ? ans.value : ans
+      const vals = Array.isArray(raw) ? raw : [raw]
       if (!map[qid]) map[qid] = {}
-      map[qid][val] = (map[qid][val] || 0) + 1
+      for (const v of vals) {
+        map[qid][v] = (map[qid][v] || 0) + 1
+      }
     }
   }
   return map
 })
+
+function formatDate(ts) {
+  return new Date(ts).toLocaleString()
+}
+
+async function printResponse(r) {
+  if (!r) return
+  await qStore.fetchOne(r.questionnaireId)
+  const doc = new jsPDF()
+  let y = 10
+  doc.setFontSize(16)
+  doc.text(qStore.current.title || r.questionnaireId, 10, y)
+  y += 10
+  doc.setFontSize(12)
+  for (const section of qStore.sections) {
+    doc.setFont(undefined, 'bold')
+    doc.text(section.title, 10, y)
+    y += 8
+    doc.setFont(undefined, 'normal')
+    for (const q of qStore.questionsBySection(section.id)) {
+      const source = section.adminOnly ? r.adminAnswers || {} : r.answers || {}
+      const ans = source[q.id]?.value || source[q.id] || ''
+      const line = `${q.prompt}: ${Array.isArray(ans) ? ans.join(', ') : ans}`
+      const lines = doc.splitTextToSize(line, 190)
+      for (const l of lines) {
+        if (y > 280) {
+          doc.addPage()
+          y = 10
+        }
+        doc.text(l, 10, y)
+        y += 7
+      }
+    }
+    y += 4
+  }
+  doc.save('response.pdf')
+}
 </script>
 
 <template>
   <div class="p-4">
-    <h1 class="text-2xl font-bold mb-4">Rezultate</h1>
-    <div class="max-w-xl grid gap-4 sm:grid-cols-2">
-      <div>
-        <label class="block text-sm mb-1">Chestionar</label>
-        <select
-          v-model="selectedQuestionnaire"
-          @change="load"
-          class="border p-2 rounded w-full"
-        >
-          <option value="" disabled>Selectează...</option>
-          <option v-for="q in questionnaires" :key="q.id" :value="q.id">{{ q.title }}</option>
-        </select>
+    <div class="max-w-3xl mx-auto bg-white p-6 rounded shadow">
+      <RouterLink to="/admin" class="text-blue-600 underline mb-4 inline-block">
+        &larr; Înapoi
+      </RouterLink>
+      <h1 class="text-2xl font-bold mb-4 text-center">Rezultate</h1>
+      <div class="grid gap-4 sm:grid-cols-2 mb-6">
+        <div>
+          <label class="block text-sm mb-1">Chestionar</label>
+          <select
+            v-model="selectedQuestionnaire"
+            @change="load"
+            class="border p-2 rounded w-full"
+          >
+            <option value="" disabled>Selectează...</option>
+            <option v-for="q in questionnaires" :key="q.id" :value="q.id">{{ q.title }}</option>
+          </select>
+        </div>
       </div>
-    </div>
 
-    <div v-if="selectedQuestionnaire" class="mt-8">
-      <h2 class="text-xl font-semibold mb-4">Răspunsuri agregate</h2>
-      <div v-if="responses.length === 0" class="text-slate-600">Niciun răspuns deocamdată.</div>
-      <div v-for="q in qStore.questions" :key="q.id" class="mb-6">
-        <h3 class="font-medium mb-2">{{ q.prompt }}</h3>
-        <ul class="pl-4 list-disc">
-          <li v-for="(count, val) in aggregated[q.id] || {}" :key="val">{{ val }}: {{ count }}</li>
-        </ul>
+      <div v-if="selectedQuestionnaire">
+        <div class="flex justify-end mb-4">
+          <RouterLink
+            :to="`/admin/questionnaire/${selectedQuestionnaire}`"
+            class="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm"
+          >
+            Editează chestionarul
+          </RouterLink>
+        </div>
+
+        <table class="w-full text-left border mb-6" v-if="responses.length">
+          <thead>
+            <tr class="border-b bg-slate-50">
+              <th class="p-2">Client</th>
+              <th class="p-2">Data</th>
+              <th class="p-2">Acțiuni</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="r in responses" :key="r.id" class="border-b last:border-b-0">
+              <td class="p-2">{{ r.customerEmail || r.userId }}</td>
+              <td class="p-2 text-sm text-slate-600">{{ formatDate(r.submittedAt) }}</td>
+              <td class="p-2">
+                <button
+                  class="px-2 py-1 bg-slate-200 hover:bg-slate-300 rounded text-sm"
+                  @click="printResponse(r)"
+                >
+                  PDF
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div v-else class="text-slate-600 mb-6">Niciun răspuns deocamdată.</div>
+
+        <h2 class="text-xl font-semibold mb-4">Răspunsuri agregate</h2>
+        <div v-for="q in qStore.questions" :key="q.id" class="mb-6">
+          <h3 class="font-medium mb-2">{{ q.prompt }}</h3>
+          <ul class="pl-4 list-disc">
+            <li v-for="(count, val) in aggregated[q.id] || {}" :key="val">{{ val }}: {{ count }}</li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add admin results view with customer list, edit link, and PDF export
- support text, radio, and multiple choice questions in builder and runner
- standardize page layouts with centered cards and back navigation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b595288140832ea2428fa2a09ee9fc