### PR TITLE
Improve mobile controls for easier tapping

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,9 +35,11 @@ $(function() {
     if (current >= stages.length) {
       $('#status').text('Done');
       sounds.stop.play();
-      $('#stopBtn, #pauseBtn').addClass('d-none');
-      $('#startBtn').prop('disabled', false);
+      $('#toggleBtn').removeClass('btn-warning').addClass('btn-success').html('<i class="bi bi-play-fill"></i> Start').prop('disabled', false);
+      $('#stopBtn').prop('disabled', true);
       $('#setup-form').removeClass('d-none');
+      $('#counter').text('STOPPED');
+      stages = [];
       return;
     }
 
@@ -68,35 +70,32 @@ $(function() {
       } else {
         clearInterval(countdownInterval);
         countdownInterval = null;
-        $('#pauseBtn').prop('disabled', false);
+        $('#toggleBtn').prop('disabled', false);
         runStage();
       }
     }, 1000);
   }
 
-  $('#startBtn').on('click', function() {
-    const stations = parseInt($('#stations').val(), 10);
-    const exercise = parseInt($('#exercise').val(), 10);
-    const pause = parseInt($('#pause').val(), 10);
+  $('#toggleBtn').on('click', function() {
+    if (stages.length === 0 && !timer && !countdownInterval) {
+      const stations = parseInt($('#stations').val(), 10);
+      const exercise = parseInt($('#exercise').val(), 10);
+      const pause = parseInt($('#pause').val(), 10);
 
-    stages = [];
-    for (let i = 1; i <= stations; i++) {
-      stages.push({ type: 'exercise', seconds: exercise, number: i });
-      if (i < stations) {
-        stages.push({ type: 'pause', seconds: pause });
+      stages = [];
+      for (let i = 1; i <= stations; i++) {
+        stages.push({ type: 'exercise', seconds: exercise, number: i });
+        if (i < stations) {
+          stages.push({ type: 'pause', seconds: pause });
+        }
       }
-    }
 
-    current = 0;
-    $('#startBtn').prop('disabled', true);
-    $('#stopBtn, #pauseBtn').removeClass('d-none');
-    $('#pauseBtn').prop('disabled', true);
-    $('#setup-form').addClass('d-none');
-    initialCountdown();
-  });
-
-  $('#pauseBtn').on('click', function() {
-    if (timer) {
+      current = 0;
+      $(this).prop('disabled', true).removeClass('btn-success').addClass('btn-warning').html('<i class="bi bi-pause-fill"></i> Pause');
+      $('#stopBtn').prop('disabled', false);
+      $('#setup-form').addClass('d-none');
+      initialCountdown();
+    } else if (timer) {
       clearInterval(timer);
       timer = null;
       $(this).html('<i class="bi bi-play-fill"></i> Resume');
@@ -123,12 +122,12 @@ $(function() {
     }
     sounds.countdown.pause();
     sounds.countdown.currentTime = 0;
-    $('#startBtn').prop('disabled', false);
-    $('#stopBtn, #pauseBtn').addClass('d-none');
-    $('#pauseBtn').html('<i class="bi bi-pause-fill"></i> Pause').prop('disabled', true);
+    $('#toggleBtn').removeClass('btn-warning').addClass('btn-success').html('<i class="bi bi-play-fill"></i> Start').prop('disabled', false);
+    $('#stopBtn').prop('disabled', true);
     $('#status').text('Stopped');
-    $('#counter').text('00');
+    $('#counter').text('STOPPED');
     $('#setup-form').removeClass('d-none');
     sounds.stop.play();
+    stages = [];
   });
 });

--- a/index.html
+++ b/index.html
@@ -26,26 +26,27 @@
     <h1 class="mb-4">Circuit Counter PRO</h1>
 
     <form id="setup-form" class="mb-4">
-      <div class="mb-3">
-        <label for="stations" class="form-label">Stations / Exercises</label>
-        <input type="number" id="stations" class="form-control" min="1" value="5">
+      <div class="row g-2">
+        <div class="col">
+          <label for="stations" class="form-label">Stations / Exercises</label>
+          <input type="number" id="stations" class="form-control form-control-lg text-center" min="1" value="5">
+        </div>
+        <div class="col">
+          <label for="exercise" class="form-label">Seconds per exercise</label>
+          <input type="number" id="exercise" class="form-control form-control-lg text-center" min="1" value="30">
+        </div>
+        <div class="col">
+          <label for="pause" class="form-label">Pause seconds</label>
+          <input type="number" id="pause" class="form-control form-control-lg text-center" min="1" value="15">
+        </div>
       </div>
-      <div class="mb-3">
-        <label for="exercise" class="form-label">Seconds per exercise</label>
-        <input type="number" id="exercise" class="form-control" min="1" value="30">
-      </div>
-      <div class="mb-3">
-        <label for="pause" class="form-label">Pause seconds</label>
-        <input type="number" id="pause" class="form-control" min="1" value="15">
-      </div>
-      <button type="button" id="startBtn" class="btn btn-success w-100"><i class="bi bi-play-fill"></i> Start</button>
     </form>
 
     <div id="status" class="h3 mb-2"></div>
-    <div id="counter" class="digital">00</div>
-    <div class="w-100">
-      <button type="button" id="pauseBtn" class="btn btn-warning w-100 mt-3 d-none"><i class="bi bi-pause-fill"></i> Pause</button>
-      <button type="button" id="stopBtn" class="btn btn-danger w-100 mt-2 d-none"><i class="bi bi-stop-fill"></i> Stop</button>
+    <div id="counter" class="digital">STOPPED</div>
+    <div class="d-flex gap-3 mt-3">
+      <button type="button" id="toggleBtn" class="btn btn-success btn-lg flex-fill"><i class="bi bi-play-fill"></i> Start</button>
+      <button type="button" id="stopBtn" class="btn btn-danger btn-lg flex-fill" disabled><i class="bi bi-stop-fill"></i> Stop</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Layout: Inputs for stations, exercise seconds, and pause seconds now align in one row
- Controls: Replaced separate start/pause/stop buttons with larger Start/Pause toggle and Stop button side by side
- Display: Shows **STOPPED** when idle instead of `00`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdee09c7b4832ea8324d5f4f8fd63e