### PR TITLE
Swap heading text for logo and enable PWA auto updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 <body class="bg-dark text-light d-flex flex-column min-vh-100">
 
   <div class="container py-4 my-auto text-center">
-    <h1 class="mb-4">Circuit Counter PRO</h1>
+    <img src="res/android/android-launchericon-192-192.png" alt="Circuit Counter PRO logo" class="mb-4" width="192" height="192" />
 
     <form id="setup-form" class="mb-4">
       <div class="row g-2">

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "circuit-counter-cache-v1";
+const CACHE_NAME = "circuit-counter-cache-v2";
 const ASSETS = [
   "/",
   "/index.html",
@@ -36,6 +36,12 @@ self.addEventListener("activate", event => {
 // Fetch
 self.addEventListener("fetch", event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    fetch(event.request)
+      .then(response => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        return response;
+      })
+      .catch(() => caches.match(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- Display app logo instead of text header
- Fetch network-first and update cache to auto-refresh PWA assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdef9808e8832e81d1a5fa3229ffb5