### PR TITLE
Prevent screen sleep during timer

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,23 @@ $(function() {
     countdown: new Audio('321-counter.mp3')
   };
 
+  const noSleep = new NoSleep();
+  let wakeLockEnabled = false;
+
+  function enableNoSleep() {
+    if (!wakeLockEnabled) {
+      noSleep.enable();
+      wakeLockEnabled = true;
+    }
+  }
+
+  function disableNoSleep() {
+    if (wakeLockEnabled) {
+      noSleep.disable();
+      wakeLockEnabled = false;
+    }
+  }
+
   let stages = [], current = 0, timer = null, timeLeft = 0, stage = null, countdownInterval = null;
 
   function padTo2Digits(num) {
@@ -44,6 +61,7 @@ $(function() {
       $('#setup-form').removeClass('disabled');
       $('#counter').text('00');
       stages = [];
+      disableNoSleep();
       return;
     }
 
@@ -99,9 +117,11 @@ $(function() {
       $('#stopBtn').prop('disabled', false);
       $('#setup-form').addClass('disabled');
       initialCountdown();
+      enableNoSleep();
     } else if (timer) {
       clearInterval(timer);
       timer = null;
+      disableNoSleep();
       $(this).html('<i class="bi bi-play-fill"></i> Resume');
       sounds.start.pause();
       sounds.start.currentTime = 0;
@@ -109,6 +129,7 @@ $(function() {
       sounds.pause.play();
     } else {
       startTimer();
+      enableNoSleep();
       $(this).html('<i class="bi bi-pause-fill"></i> Pause');
       sounds.pause.pause();
       sounds.pause.currentTime = 0;
@@ -133,5 +154,6 @@ $(function() {
     $('#setup-form').removeClass('disabled');
     sounds.stop.play();
     stages = [];
+    disableNoSleep();
   });
 });

--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <!-- NoSleep to keep the screen awake on mobile devices -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/noSleep/0.12.0/NoSleep.min.js"></script>
   <script src="app.js"></script>
 
   <!-- Register Service Worker -->


### PR DESCRIPTION
## Summary
- load NoSleep.js to keep the display awake
- toggle wake lock when the timer starts, pauses, or stops

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfdfd29b8832ebc485fc332d6c9f8