### PR TITLE
Add global stopwatch timer

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ $(function() {
   }
 
   let stages = [], current = 0, timer = null, timeLeft = 0, stage = null, countdownInterval = null;
+  let globalInterval = null, globalStartTime = 0, globalElapsed = 0;
 
   function padTo2Digits(num) {
     return num.toString().padStart(2, '0');
@@ -32,6 +33,40 @@ $(function() {
 
   function updateDisplay() {
     $('#counter').text(padTo2Digits(timeLeft));
+  }
+
+  function updateGlobalDisplay() {
+    const elapsed = globalElapsed + (Date.now() - globalStartTime);
+    const hours = Math.floor(elapsed / 3600000);
+    const minutes = Math.floor((elapsed % 3600000) / 60000);
+    const seconds = Math.floor((elapsed % 60000) / 1000);
+    const milliseconds = elapsed % 1000;
+    $('#global-counter').text(
+      `${padTo2Digits(hours)}:${padTo2Digits(minutes)}:${padTo2Digits(seconds)}.${milliseconds.toString().padStart(3, '0')}`
+    );
+  }
+
+  function startGlobalTimer() {
+    globalStartTime = Date.now();
+    updateGlobalDisplay();
+    globalInterval = setInterval(updateGlobalDisplay, 10);
+  }
+
+  function pauseGlobalTimer() {
+    clearInterval(globalInterval);
+    globalElapsed += Date.now() - globalStartTime;
+  }
+
+  function resumeGlobalTimer() {
+    startGlobalTimer();
+  }
+
+  function stopGlobalTimer() {
+    clearInterval(globalInterval);
+    globalInterval = null;
+    globalStartTime = 0;
+    globalElapsed = 0;
+    $('#global-counter').text('00:00:00.000');
   }
 
   function startTimer() {
@@ -62,6 +97,7 @@ $(function() {
       $('#counter').text('00');
       stages = [];
       disableNoSleep();
+      stopGlobalTimer();
       return;
     }
 
@@ -116,6 +152,8 @@ $(function() {
       $(this).prop('disabled', true).removeClass('btn-success').addClass('btn-warning').html('<i class="bi bi-pause-fill"></i> Pause');
       $('#stopBtn').prop('disabled', false);
       $('#setup-form').addClass('disabled');
+      globalElapsed = 0;
+      startGlobalTimer();
       initialCountdown();
       enableNoSleep();
     } else if (timer) {
@@ -127,6 +165,7 @@ $(function() {
       sounds.start.currentTime = 0;
       sounds.pause.currentTime = 0;
       sounds.pause.play();
+      pauseGlobalTimer();
     } else {
       startTimer();
       enableNoSleep();
@@ -135,6 +174,7 @@ $(function() {
       sounds.pause.currentTime = 0;
       sounds.start.currentTime = 0;
       sounds.start.play();
+      resumeGlobalTimer();
     }
   });
 
@@ -155,5 +195,6 @@ $(function() {
     sounds.stop.play();
     stages = [];
     disableNoSleep();
+    stopGlobalTimer();
   });
 });

--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
     </form>
 
     <div id="status" class="h3 mb-1">Stopped</div>
-    <div id="counter" class="digital pb-6">00</div>
+    <div id="counter" class="digital">00</div>
+    <div id="global-counter" class="digital pb-6">00:00:00.000</div>
     <div class="d-flex fixed-bottom bg-dark gap-3 p-4 pb-5">
       <button type="button" id="toggleBtn" class="btn btn-success btn-lg flex-fill"><i class="bi bi-play-fill"></i> Start</button>
       <button type="button" id="stopBtn" class="btn btn-danger btn-lg flex-fill" disabled><i class="bi bi-stop-fill"></i> Stop</button>

--- a/style.css
+++ b/style.css
@@ -31,6 +31,11 @@ body {
   height: 45vh;
 }
 
+#global-counter {
+  font-size: 5vh;
+  line-height: 1;
+}
+
 .digital {
   font-family: 'Share Tech Mono', monospace;
 }


### PR DESCRIPTION
## Summary
- Show a global stopwatch below the main counter tracking total workout time
- Support pause, resume, and stop for the global timer alongside the stage timer
- Style the global counter as a smaller digital display

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be0250efb4832ea639b42ed39ba473